### PR TITLE
Nissix plugin scope-packages on repro-wsr-1628

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const bootstrap = require('wix-bootstrap-ng');
+const bootstrap = require('@wix/wix-bootstrap-ng');
 
 const rootDir = process.env.SRC_PATH || './dist/src';
 const getPath = filename => path.join(rootDir, filename);

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "react-dom": "15.6.1",
     "react-i18next": "~4.6.0",
     "regenerator-runtime": "^0.11.0",
-    "wix-axios-config": "latest",
-    "wix-bootstrap-ng": "latest",
-    "wix-express-csrf": "latest",
-    "wix-express-require-https": "latest",
-    "wix-run-mode": "latest",
+    "@wix/wix-axios-config": "latest",
+    "@wix/wix-bootstrap-ng": "latest",
+    "@wix/wix-express-csrf": "latest",
+    "@wix/wix-express-require-https": "latest",
+    "@wix/wix-run-mode": "latest",
     "wix-style-react": "^3.1.2"
   },
   "devDependencies": {
@@ -41,9 +41,9 @@
     "jsdom": "~11.2.0",
     "jsdom-global": "~3.0.0",
     "puppeteer": "^1.1.0",
-    "wix-bootstrap-testkit": "latest",
-    "wix-config-emitter": "latest",
-    "yoshi": "^1.2.0"
+    "@wix/wix-bootstrap-testkit": "latest",
+    "@wix/wix-config-emitter": "latest",
+    "@wix/yoshi": "^1.2.0"
   },
   "yoshi": {
     "externals": {

--- a/src/client.js
+++ b/src/client.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {I18nextProvider} from 'react-i18next';
 import axios from 'axios';
-import {wixAxiosConfig} from 'wix-axios-config';
+import {wixAxiosConfig} from '@wix/wix-axios-config';
 import i18n from './i18n';
 import App from './components/App';
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,8 @@
 import 'regenerator-runtime/runtime';
-import wixRunMode from 'wix-run-mode';
+import wixRunMode from '@wix/wix-run-mode';
 import ejs from 'ejs';
-import wixExpressCsrf from 'wix-express-csrf';
-import wixExpressRequireHttps from 'wix-express-require-https';
+import wixExpressCsrf from '@wix/wix-express-csrf';
+import wixExpressRequireHttps from '@wix/wix-express-require-https';
 import {readFileSync} from 'fs';
 
 module.exports = (app, context) => {

--- a/test/environment.js
+++ b/test/environment.js
@@ -1,5 +1,5 @@
-import testkit from 'wix-bootstrap-testkit';
-import configEmitter from 'wix-config-emitter';
+import testkit from '@wix/wix-bootstrap-testkit';
+import configEmitter from '@wix/wix-config-emitter';
 
 export const app = bootstrapServer();
 

--- a/test/it/server.spec.js
+++ b/test/it/server.spec.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import adapter from 'axios/lib/adapters/http';
 import {beforeAndAfter, app} from '../environment';
 import {baseURL} from '../test-common';
-import {wixAxiosInstanceConfig} from 'wix-axios-config';
+import {wixAxiosInstanceConfig} from '@wix/wix-axios-config';
 
 const axiosInstance = wixAxiosInstanceConfig(axios, {baseURL, adapter});
 

--- a/test/mocha-setup.js
+++ b/test/mocha-setup.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import {wixAxiosConfig} from 'wix-axios-config';
+import {wixAxiosConfig} from '@wix/wix-axios-config';
 import {baseURL} from './test-common';
 
 wixAxiosConfig(axios, {baseURL});


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.379s



Output Log:
Migrating package "repro-wsr-1628" in .


## Migration from non scope to @wix/scoped packages
> /tmp/457963867f3736abeb41209008a6e5c2

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
index.js
src/client.js
src/server.js
test/environment.js
test/mocha-setup.js
test/it/server.spec.js
```

